### PR TITLE
⚡ Replace manual DOM query with Svelte bind:this in +page.svelte

### DIFF
--- a/dev_server.log
+++ b/dev_server.log
@@ -1,0 +1,5 @@
+
+> cat-math@0.0.2 dev
+> vite dev
+
+sh: 1: vite: not found

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -9,6 +9,7 @@
 	let operation: typeof data.operations[0] | null;
 	let answer = '';
 	let finished: boolean;
+	let operationDiv: HTMLElement;
 	$: operationsLeft = (operations?.length || 0) + 1;
 
 	onMount(() => {
@@ -33,7 +34,6 @@
 		if (+answer === n1 * n2) {
 			// Correct answer
 			loadOperation();
-			const operationDiv = document.getElementById('operation');
 			if (operationDiv) party.confetti(operationDiv, { count: 50, spread: 10 });
 		} else {
 			// Wrong answer
@@ -44,7 +44,7 @@
 
 <div class="main-container">
 	<div class="card">
-		<div id="operation" class="operation">
+		<div bind:this={operationDiv} id="operation" class="operation">
 			{#if finished}
 				<a href="/" target="_self">
 					<button class="btn">Reiniciar</button>


### PR DESCRIPTION
💡 **What:** Replaced `document.getElementById('operation')` with Svelte's idiomatic `bind:this={operationDiv}` directive in `src/routes/+page.svelte`.
🎯 **Why:** Svelte's `bind:this` is the idiomatic way to reference DOM elements directly, avoiding repeated DOM queries and global namespace lookups. This improves code quality and efficiency.
📊 **Measured Improvement:** Measuring the performance impact of a single `getElementById` call in this context is impractical as it is in the nanosecond range and occurs only on a correct answer. However, the change follows Svelte best practices for performance and maintainability.

---
*PR created automatically by Jules for task [9299950009402746980](https://jules.google.com/task/9299950009402746980) started by @oscarsaraza*