### PR TITLE
🔒 [security fix] Add missing radix parameter to parseInt

### DIFF
--- a/src/routes/keyboard.svelte
+++ b/src/routes/keyboard.svelte
@@ -11,7 +11,7 @@
 	const onNumberClick = (number: number) => () => addNumberToAnswer(number);
 
 	const handleKeydown = ({ key }: KeyboardEvent) => {
-		const number = parseInt(key);
+		const number = parseInt(key, 10);
 		if (!Number.isNaN(number)) addNumberToAnswer(number);
 		else if (key === 'Enter') onOkButtonClick();
 		else if (key === 'Backspace') onDelButtonClick();


### PR DESCRIPTION
This change adds the missing radix parameter `10` to the `parseInt` call in `src/routes/keyboard.svelte`. 

🎯 **What:** The vulnerability fixed is the missing radix parameter in `parseInt()`.
⚠️ **Risk:** Without an explicit radix, `parseInt()` might interpret strings with leading zeros as octal (in older environments) or have inconsistent behavior, which can lead to logic errors and potential security issues when handling user-provided strings.
🛡️ **Solution:** Added `, 10` as the second argument to `parseInt()` to ensure it always parses in base 10.

---
*PR created automatically by Jules for task [7870212991822145075](https://jules.google.com/task/7870212991822145075) started by @oscarsaraza*