### PR TITLE
🧹 Refactor duplicated numeric buttons in keyboard.svelte

### DIFF
--- a/src/routes/keyboard.svelte
+++ b/src/routes/keyboard.svelte
@@ -29,15 +29,9 @@
 <svelte:window on:keydown={handleKeydown} />
 
 <div id="keyboard">
-	<button class="btn" on:click={onNumberClick(1)}>1</button>
-	<button class="btn" on:click={onNumberClick(2)}>2</button>
-	<button class="btn" on:click={onNumberClick(3)}>3</button>
-	<button class="btn" on:click={onNumberClick(4)}>4</button>
-	<button class="btn" on:click={onNumberClick(5)}>5</button>
-	<button class="btn" on:click={onNumberClick(6)}>6</button>
-	<button class="btn" on:click={onNumberClick(7)}>7</button>
-	<button class="btn" on:click={onNumberClick(8)}>8</button>
-	<button class="btn" on:click={onNumberClick(9)}>9</button>
+	{#each [1, 2, 3, 4, 5, 6, 7, 8, 9] as n}
+		<button class="btn" on:click={onNumberClick(n)}>{n}</button>
+	{/each}
 	<button class="btn" on:click={onOkButtonClick}>✔</button>
 	<button class="btn" on:click={onNumberClick(0)}>0</button>
 	<button class="btn" on:click={onDelButtonClick}>←</button>


### PR DESCRIPTION
🎯 **What:** Refactored the numeric keypad to use a Svelte `{#each}` block for the number buttons 1-9.
💡 **Why:** This reduces code duplication and makes the component more maintainable and readable.
✅ **Verification:** I manually inspected the refactored code in `src/routes/keyboard.svelte` to ensure the logic and layout remain identical to the original implementation.
✨ **Result:** A cleaner, more idiomatic Svelte component with reduced duplication.

---
*PR created automatically by Jules for task [246503379434900579](https://jules.google.com/task/246503379434900579) started by @oscarsaraza*