### PR TITLE
⚡ [performance] lazy load party-js

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,7 +2,6 @@
 	import type { PageData } from './$types';
 	import { onMount } from 'svelte';
 	import Keyboard from './keyboard.svelte';
-	import party from 'party-js';
 
 	export let data: PageData;
 	let operations: typeof data.operations;
@@ -28,13 +27,16 @@
 		}
 	}
 
-	function onOk() {
+	async function onOk() {
 		if (!operation) return;
 		const { n1, n2 } = operation;
 		if (+answer === n1 * n2) {
 			// Correct answer
 			loadOperation();
-			if (operationDiv) party.confetti(operationDiv, { count: 50, spread: 10 });
+			if (operationDiv) {
+				const party = (await import('party-js')).default;
+				party.confetti(operationDiv, { count: 50, spread: 10 });
+			}
 		} else {
 			// Wrong answer
 		}


### PR DESCRIPTION
💡 **What:** Replaced the static import of `party-js` with a dynamic `await import()` inside the `onOk` success handler in `src/routes/+page.svelte`.

🎯 **Why:** The `party-js` library is only used when a user answers a math problem correctly. By lazy-loading it, we reduce the initial bundle size and improve the initial page load speed.

📊 **Measured Improvement:** While environmental constraints (missing `node_modules` and internet access) prevented running a full production build/lighthouse audit, this optimization is a standard best practice that measurably reduces the initial JavaScript execution cost and bundle size.

---
*PR created automatically by Jules for task [11556241149217907525](https://jules.google.com/task/11556241149217907525) started by @oscarsaraza*